### PR TITLE
Fix alpine ps => PID issue

### DIFF
--- a/bin/helpers/check-pid
+++ b/bin/helpers/check-pid
@@ -21,7 +21,7 @@ kill -0 $1 >/dev/null 2>&1
 if [ $? -eq 0 ]; then
     IFS=$'\n'
 
-    for line in $(ps ax -opid,args | grep $1 | grep zeek); do
+    for line in $(ps ax -o pid=PID____8 -o args | grep $1 | grep zeek); do
         pid=$(echo $line | awk '{print $1}')
 
         if [ "$pid" -eq $1 ]; then


### PR DESCRIPTION
This is a workaround for a bug in the busybox version of ps, as used in alpine linux for example.

The busybox  ps doesn't behave properly when the PID field gets larger than 5 digits: it gets run together with the ARGS (COMMAND) fields. As a result, check-pid can't properly select the PID (for which it uses `awk '{print $1}'`. To demonstrate the problem:

```
$ docker run -it alpine:latest
/ # for n in $(seq 100000); do (:) ; done
/ # ps ax -o pid,args
PID   COMMAND
    1 /bin/sh
100008ps ax -o pid,args
```

The fix is to artificially widen the PID field by forcing a wider column header (width 8 chosen to give a bit of wiggle room in case the OS'd PID wrapping setting is very large).

```
/ # ps ax -o pid=PID____8 -o args
PID____8 COMMAND
       1 /bin/sh
  100009 ps ax -o pid=PID____8 -o args
```

The ps syntax used works on at least standard GNU procps (used in ubuntu, centos, etc), busybox ps and Mac OSX ps and is consistent with that specified in http://pubs.opengroup.org/onlinepubs/9699919799/utilities/ps.html

