### PR TITLE
Add option to compress logs at creation instead of during rotation

### DIFF
--- a/ZeekControl/install.py
+++ b/ZeekControl/install.py
@@ -276,6 +276,9 @@ def make_zeekctl_config_policy(path, cmdout, plugin_reg):
 
     ostr += plugin_reg.getZeekctlConfig(cmdout)
 
+    if config.Config.compresslogsinflight:
+        ostr += 'redef LogAscii::gzip_level = 7;\n'
+
     filename = os.path.join(path, "zeekctl-config.zeek")
     try:
         with open(filename, "w") as out:

--- a/ZeekControl/install.py
+++ b/ZeekControl/install.py
@@ -278,6 +278,7 @@ def make_zeekctl_config_policy(path, cmdout, plugin_reg):
 
     if config.Config.compresslogsinflight:
         ostr += 'redef LogAscii::gzip_level = 7;\n'
+        ostr += 'redef LogAscii::gzip_file_extension = "%s";\n' % config.Config.compressextension
 
     filename = os.path.join(path, "zeekctl-config.zeek")
     try:

--- a/ZeekControl/options.py
+++ b/ZeekControl/options.py
@@ -52,6 +52,8 @@ options = [
            "Script to generate filenames for archived log files."),
     Option("CompressLogs", 1, "bool", Option.USER, False,
            "True to compress archived log files."),
+    Option("CompressLogsInFlight", 0, "bool", Option.USER, False,
+           "True to compress archived log files as they're created instead of during rotation. If this is enabled, the CompressLogs, CompressCmd, and CompressExtension arguments will be ignored as the files are compressed automatically by Zeek."),
     Option("CompressCmd", "gzip -9", "string", Option.USER, False,
            "If archived logs will be compressed, the command to use for that. The specified command must compress its standard input to standard output."),
     Option("CompressExtension", "gz", "string", Option.USER, False,

--- a/doc/zeekctl.rst
+++ b/doc/zeekctl.rst
@@ -757,6 +757,11 @@ User Options
 *CompressLogs* (bool, default 1)
     True to compress archived log files.
 
+.. _CompressLogsInFlight:
+
+*CompressLogsInFlight* (bool, default 0)
+    True to have compress log files at creation time instead of during log rotation. If this is set to 1, the CompressLogs option will be ignored.
+
 .. _ControlTopic:
 
 *ControlTopic* (string, default "zeek/control")


### PR DESCRIPTION
Fixes https://github.com/zeek/zeek/issues/360