### PR TITLE
Rollback check-pid to pre-Alpine-support status.

### DIFF
--- a/bin/helpers/check-pid
+++ b/bin/helpers/check-pid
@@ -4,31 +4,10 @@
 #
 #  check-pid <pid>
 
-if [[ $(uname -s) == Darwin ]]; then
-    ps -p $1 -o args | grep -q zeek
-
-    if [ $? -eq 0 ]; then
-        echo "running"
-    else
-        echo "not running"
-    fi
-
-    exit 0
-fi
-
-kill -0 $1 >/dev/null 2>&1
+ps -p $1 -o args | grep -q zeek
 
 if [ $? -eq 0 ]; then
-    IFS=$'\n'
-
-    for line in $(ps ax -o pid=PID____8 -o args | grep $1 | grep zeek); do
-        pid=$(echo $line | awk '{print $1}')
-
-        if [ "$pid" -eq $1 ]; then
-            echo "running"
-            exit 0
-        fi
-    done
+    echo "running"
+else
+    echo "not running"
 fi
-
-echo "not running"


### PR DESCRIPTION
This basically rolls the status of the script back 49e2887201a9a3525a4185ca58d85485ec3cbbc4. This breaks GH-10.

The reason for this change are discussed in https://github.com/zeek/zeek/issues/518). At least on Ubuntu systems, the kill -0 approach does not seem to work reliably.