### PR TITLE
CMakeLists.txt: don't check for sqlite3 python module when cross-compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,12 +52,14 @@ if (MISSING_PREREQS)
     message(FATAL_ERROR "Configuration aborted due to missing prerequisites")
 endif ()
 
-execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "import sqlite3"
-                RESULT_VARIABLE PYSQLITE3_IMPORT_RESULT)
+if (NOT CMAKE_CROSSCOMPILING)
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "import sqlite3"
+                    RESULT_VARIABLE PYSQLITE3_IMPORT_RESULT)
 
-if ( NOT PYSQLITE3_IMPORT_RESULT EQUAL 0 )
-    message(FATAL_ERROR "The sqlite3 python module is required to use "
-            "ZeekControl, but was not found.  Configuration aborted.")
+    if ( NOT PYSQLITE3_IMPORT_RESULT EQUAL 0 )
+        message(FATAL_ERROR "The sqlite3 python module is required to use "
+                "ZeekControl, but was not found.  Configuration aborted.")
+    endif ()
 endif ()
 
 if (NOT ZEEK_ROOT_DIR)


### PR DESCRIPTION
Don't check for sqlite3 python module support by calling
"${PYTHON_EXECUTABLE}" -c "import sqlite3" when cross-compiling as this
will check sqlite3 support on the host python interpreter and not the
target python interpreter.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>