### PR TITLE
Update CMake logic to prefer Python 3 over Python 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ else ()
 endif ()
 
 find_package(Zeek)
+list(APPEND Python_ADDITIONAL_VERSIONS 3)
 FindRequiredPackage(PythonInterp)
 FindRequiredPackage(SubnetTree)
 find_package(PCAP)


### PR DESCRIPTION
Fixes #27 