### PR TITLE
GH-32: Add builtin-plugins to ZEEKPATH in set-zeek-path

### DIFF
--- a/bin/set-zeek-path
+++ b/bin/set-zeek-path
@@ -5,7 +5,7 @@
 #
 # Should be sourced.
 
-ZEEKPATH=${tmp_node_dir}:${policydirsiteinstallauto}:${policydir}:${policydir}/policy:${policydir}/site
+ZEEKPATH=${tmp_node_dir}:${policydirsiteinstallauto}:${policydir}:${policydir}/policy:${policydir}/site:${policydir}/builtin-plugins
 
 if [ "$use_installed_policies" = "1" ]; then
    export ZEEKPATH=${policydirsiteinstall}:$ZEEKPATH


### PR DESCRIPTION
Fixes #32 