### PR TITLE
Have `make dist` cleanup a few more wayward files before tarring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,20 @@ install: configured
 clean: configured
 	$(MAKE) -C $(BUILD) $@
 
+# The COPYFILE_DISABLE flag used in the tar command below is an undocumented feature
+# of the tar binary on macOS. It causes tar to avoid including any of the special files
+# that macOS litters around the repository directory, such as ._ resource files, none
+# of which should be included in the distribution packages.
 dist:
 	@test -e ../$(VERSION_FULL) && rm -ri ../$(VERSION_FULL) || true
 	@cp -R . ../$(VERSION_FULL)
 	@for i in . $$(git submodule foreach -q --recursive realpath --relative-to=$$(pwd) .); do ((cd ../$(VERSION_FULL)/$$i && test -f .git && cp -R $(GITDIR) .gitnew && rm -f .git && mv .gitnew .git && sed -i.bak -e 's#[[:space:]]*worktree[[:space:]]*=[[:space:]]*.*##g' .git/config) || true); done
 	@for i in . $$(git submodule foreach -q --recursive realpath --relative-to=$$(pwd) .); do (cd ../$(VERSION_FULL)/$$i && git reset -q --hard && git clean -ffdxq); done
 	@(cd ../$(VERSION_FULL) && find . -name \.git\* | xargs rm -rf)
+	@(cd ../$(VERSION_FULL) && find . -name \.idea -type d | xargs rm -rf)
+	@(cd ../$(VERSION_FULL) && find . -name build\* -type d | xargs rm -rf)
 	@mv ../$(VERSION_FULL) .
-	@tar -czf $(VERSION_FULL).tar.gz $(VERSION_FULL)
+	@COPYFILE_DISABLE=true tar -czf $(VERSION_FULL).tar.gz $(VERSION_FULL)
 	@echo Package: $(VERSION_FULL).tar.gz
 	@rm -rf $(VERSION_FULL)
 


### PR DESCRIPTION
This PR migrates the changes from https://github.com/zeek/zeek/pull/1924 into this repo as well to avoid the same issues. I tested this by comparing the output from `make dist` on master and this branch on Linux and the file listings are identical, minus the binary files from macOS.