### PR TITLE
pf_ring: add new 'inner' load balancing strategies

### DIFF
--- a/ZeekControl/options.py
+++ b/ZeekControl/options.py
@@ -124,7 +124,7 @@ options = [
     Option("PFRINGClusterID", 21, "int", Option.USER, False,
            "If PF_RING flow-based load balancing is desired, this is where the PF_RING cluster id is defined.  In order to use PF_RING, the value of this option must be non-zero."),
     Option("PFRINGClusterType", "4-tuple", "string", Option.USER, False,
-           "If PF_RING flow-based load balancing is desired, this is where the PF_RING cluster type is defined.  Allowed values are: 2-tuple, 4-tuple, 5-tuple, tcp-5-tuple, 6-tuple, or round-robin.  Zeek must be linked with PF_RING's libpcap wrapper and PFRINGClusterID must be non-zero for this option to work."),
+           "If PF_RING flow-based load balancing is desired, this is where the PF_RING cluster type is defined.  Allowed values are: 2-tuple, 4-tuple, 5-tuple, tcp-5-tuple, 6-tuple, inner-2-tuple, inner-4-tuple, inner-5-tuple, inner-tcp-5-tuple, inner-6-tuple, or round-robin.  Zeek must be linked with PF_RING's libpcap wrapper and PFRINGClusterID must be non-zero for this option to work."),
     Option("PFRINGFirstAppInstance", 0, "int", Option.USER, False,
            "The first application instance for a PF_RING dnacluster interface to use.  Zeekctl will start at this application instance number and increment for each new process running on that DNA cluster.  Zeek must be linked with PF_RING's libpcap wrapper, PFRINGClusterID must be non-zero, and you must be using PF_RING+DNA and libzero for this option to work."),
 

--- a/ZeekControl/plugins/lb_pf_ring.py
+++ b/ZeekControl/plugins/lb_pf_ring.py
@@ -35,7 +35,7 @@ class LBPFRing(ZeekControl.plugin.Plugin):
 
         pfringtype = ZeekControl.config.Config.pfringclustertype
         if pfringtype is None:
-            pfringtype = '6-tuple'
+            pfringtype = "6-tuple"
 
         if pfringtype not in self.LB_POLICIES_ENV_MAP:
             self.error("Invalid configuration: PFRINGClusterType=%s" % pfringtype)


### PR DESCRIPTION
This PR adds support for the more recent "INNER" clustering strategies of PF_RING. These allow load balancing according to the IP addresses and ports inside (for instance) GRE tunnels, rather than according to the tunnel's IP. This was leading to huge balancing issues on some sensors we run.

The features themselves have been present in the PF_RING driver for a while, and my patch for PF_RING's libpcap has recently been merged: https://github.com/ntop/PF_RING/commit/7a2d111b6f7ff18339d0906729a7400773b96ff3