### PR TITLE
Add ZeekPortWarning plugin

### DIFF
--- a/ZeekControl/plugins/zeek_port_warning.py
+++ b/ZeekControl/plugins/zeek_port_warning.py
@@ -1,0 +1,83 @@
+"""
+A plugin warning about the ZeekPort change coming with Zeek 5.2.
+"""
+import textwrap
+
+import ZeekControl.plugin
+import ZeekControl.cmdresult
+
+
+
+class ZeekPortWarningPlugin(ZeekControl.plugin.Plugin):
+    def __init__(self):
+        super(ZeekPortWarningPlugin, self).__init__(apiversion=1)
+
+    def name(self):
+        return "ZeekPort warning"
+
+    def prefix(self):
+        return "zeek_port_warning"
+
+    def pluginVersion(self):
+        return 1
+
+    def options(self):
+        return [("disable", "bool", False, "Disable the ZeekPort warning.")]
+
+    def warning_banner(self, text):
+        for i, line in enumerate(text.splitlines()):
+            if i == 0 and not line:
+                continue
+            self.message("WARNING: " + line)
+
+    def init(self):
+        """
+        Print a warning about the change of the ZeekPort option.
+
+        We're just assuming that if it's 47760, the default was selected.
+        """
+        if self.getOption("disable"):
+            return
+
+        zeek_port = self.getGlobalOption("ZeekPort")
+        uses_old_default_port = (zeek_port == 47760)
+
+        if uses_old_default_port:
+            self.warning_banner("*" * 80)
+            if self.getGlobalOption("os") == "Linux":
+                self.warning_banner(textwrap.dedent(
+                    """
+                    You're using Linux with the default ZeekPort setting 47760. This configuration
+                    is know to cause persistent worker failures with error messages as follows:
+
+                        error in <...>/cluster/setup-connections.zeek, lines 94-96: Failed to listen on INADDR_ANY:47764 (...)
+
+                    """))
+
+            self.warning_banner(textwrap.dedent("""
+                Starting with Zeek 5.2, the default ZeekPort used by zeekctl will
+                change from 47760 to 27760 in order to avoid potential port collisions
+                with other processes due to 47760 falling right into Linux's default
+                ephemeral port range.
+
+                Consider changing the ZeekPort option in your zeekctl.cfg to 27760
+                now to prepare for this change. Doing so will silence this warning.
+
+                    ZeekPort = 27760
+
+                Note, if you're employing strict firewall rules between Zeek nodes,
+                you'll likely need to update these rules. If you're using Zeek on
+                a single physical host, no further action should be required.
+                If possible do test the change in a non-production environment.
+
+                To silence this warning without changing the ZeekPort option,
+                set zeek_port_warning.disable = 1 in zeekctl.cfg.
+
+                See the following PR for more details:
+                    https://github.com/zeek/zeekctl/pull/41
+
+                Feel free to reach out on zeekorg.slack.com or community.zeek.org if
+                you have any questions around this change.
+            """))
+
+            self.warning_banner("*" * 80)

--- a/testing/Scripts/build-zeek
+++ b/testing/Scripts/build-zeek
@@ -32,6 +32,11 @@ build_zeek() {
         export LDFLAGS=-L`python-config --exec-prefix`/lib
     fi
 
+    ccache_arg=""
+    if command -v ccache; then
+        ccache_arg="--ccache"
+    fi
+
     if [ -n "${ZEEKCTL_TEST_USEBUILD}" ]; then
         # Reuse a previous build in the default Zeek build directory.
         BUILDPREFIX=build
@@ -40,14 +45,14 @@ build_zeek() {
         # build). Also specify a libdir so we know we're using "lib"
         # as our library prefix -- it's used throughout the testsuite.
         ./configure --prefix="${INSTALLPREFIX}" --libdir="${INSTALLPREFIX}/lib" \
-                    ${ZEEKCTL_TEST_BUILDARGS}
+                    ${ZEEKCTL_TEST_BUILDARGS} ${ccache_arg}
     else
         # Use a build directory specifically for zeekctl tests.
         BUILDPREFIX=${ZEEKCTLBUILDDIR}/zeek-build
         # Additional configure options are used here to reduce the build size.
         ./configure --builddir=${BUILDPREFIX} --prefix="${INSTALLPREFIX}" \
                     --libdir="${INSTALLPREFIX}/lib" --build-type=Release \
-                    --disable-auxtools ${ZEEKCTL_TEST_BUILDARGS}
+                    --disable-auxtools ${ZEEKCTL_TEST_BUILDARGS} ${ccache_arg}
     fi
 
     test $? -ne 0 && return 1

--- a/testing/Scripts/build-zeek
+++ b/testing/Scripts/build-zeek
@@ -82,7 +82,7 @@ replaceprefix() {
     pydir="$($INSTALLPREFIX/bin/zeek-config --python_dir)"
 
     oldpath=`grep '^ZEEKSCRIPTDIR' $pydir/zeekctl/ZeekControl/version.py | awk -F \" '{ print $2 }'`
-    newpath=`canonicalpath "$oldpath"`
+    newpath=`realpath "$oldpath"`
     if [ "$newpath" != "$oldpath" ]; then
         for i in $pydir/zeekctl/ZeekControl/version.py ; do
             sed "s#$oldpath#$newpath#" $i > $i.new && cp $i.new $i && rm $i.new
@@ -95,13 +95,6 @@ replaceprefix() {
             return 1
         fi
     done
-}
-
-# Normalize the specified pathname by resolving any symlinks in the path.
-canonicalpath() {
-    newpath=`python -c "from __future__ import print_function; import os,sys; print(os.path.realpath(sys.argv[1]))" "$1"`
-    test $? -ne 0 && exit 1
-    echo $newpath
 }
 
 # Remove the tar file and all test-specific Zeek installation directories.
@@ -129,7 +122,7 @@ definevars() {
     ZEEKSRCDIR=${ZEEKCTLSRCDIR}/../..
 
     # Path to the ZeekControl "build" directory.
-    ZEEKCTLBUILDDIR=`canonicalpath "${ZEEKCTLSRCDIR}/build"`
+    ZEEKCTLBUILDDIR=`realpath "${ZEEKCTLSRCDIR}/build"`
 
     # Absolute path of parent directory where Zeek will be installed.
     ZEEKCTL_TEST=${ZEEKCTLBUILDDIR}/testing


### PR DESCRIPTION
@ckreibich - think that does it?

```
$ sudo ./bin/zeekctl 
WARNING: ********************************************************************************
WARNING: You're using Linux with the default ZeekPort setting 47760. This configuration
WARNING: is know to cause persistent worker failures with error messages as follows:
WARNING: 
WARNING:     error in <...>/cluster/setup-connections.zeek, lines 94-96: Failed to listen on INADDR_ANY:47764 (...)
WARNING: 
WARNING: Starting with Zeek 5.2, the default ZeekPort used by zeekctl will
WARNING: change from 47760 to 27760 in order to avoid potential port collisions
WARNING: with other processes due to 47760 falling right into Linux's default
WARNING: ephemeral port range.
WARNING: 
WARNING: Consider changing the ZeekPort option in your zeekctl.cfg to 27760
WARNING: now to prepare for this change. Doing so will silence this warning.
WARNING: 
WARNING:     ZeekPort = 27760
WARNING: 
WARNING: Note, if you're employing strict firewall rules between Zeek nodes,
WARNING: you'll likely need to update these rules. If you're using Zeek on
WARNING: a single physical host, no further action should be required.
WARNING: If possible do test the change in a non-production environment.
WARNING: 
WARNING: To silence this warning without changing the ZeekPort option,
WARNING: set zeek_port_warning.disable = 1 in zeekctl.cfg.
WARNING: 
WARNING: See the following PR for more details:
WARNING:     https://github.com/zeek/zeekctl/pull/41
WARNING: 
WARNING: Feel free to reach out on zeekorg.slack.com or community.zeek.org if
WARNING: you have any questions around this change.
WARNING: ********************************************************************************
```

Feel free to do any word-smithing in the PR.