### PR TITLE
[Bugfix] Changed the deprecated SafeConfigParser attribute to ConfigParser

### DIFF
--- a/ZeekControl/config.py
+++ b/ZeekControl/config.py
@@ -386,7 +386,7 @@ class Configuration:
 
     # Parse node.cfg.
     def _read_nodes(self):
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         fname = self.nodecfg
         try:
             if not config.read(fname):


### PR DESCRIPTION
As per your instructions, I got rid of the deprecated SafeConfigParse attribute from the config.py file and replaced it with ConfigParser attribute.