### PR TITLE
Stop installing the broctl symlink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,7 +269,6 @@ if ( NOT BINARY_PACKAGING_MODE )
   ")
 endif ()
 
-InstallSymlink("${PY_MOD_INSTALL_DIR}/zeekctl" "${LIBDIR}/broctl")
 install(DIRECTORY BroControl DESTINATION ${PY_MOD_INSTALL_DIR}/zeekctl)
 
 ########################################################################


### PR DESCRIPTION
`broctl` should really have been dead a long time ago, so stop installing a symlink for it. Fixes #68 