### PR TITLE
Avoid rebuilding Zeek for each test run

### DIFF
--- a/testing/Makefile
+++ b/testing/Makefile
@@ -1,22 +1,26 @@
+DIAG := diag.log
+BTEST := ../../btest/btest
 
-DIAG=diag.log
-BTEST=../../btest/btest
+ZEEK_TAR := ../build/testing/zeek-test-install.tar
 
-all: cleanup buildzeek btest-verbose
+all: btest-verbose
 
 # Showing all tests.
-btest-verbose:
+btest-verbose: $(ZEEK_TAR)
 	@$(BTEST) -j -f $(DIAG)
 
-brief: cleanup buildzeek btest-brief
+brief: cleanup btest-brief
 
 # Brief output showing only failed tests.
-btest-brief:
+btest-brief: $(ZEEK_TAR)
 	@$(BTEST) -j -b -f $(DIAG)
 
 # Rerun only the failed tests.
-rerun:
+rerun: $(ZEEK_TAR)
 	@$(BTEST) -r -j -f $(DIAG)
+
+$(ZEEK_TAR):
+	@./Scripts/build-zeek
 
 buildzeek:
 	@./Scripts/build-zeek


### PR DESCRIPTION
The test `Makefile` would previously always run the `buildzeek` target when running the default target. This is not necessary as building Zeek once is sufficient.

In this patch we also fix the setup so it works with parallel builds. Before it might have run cleanup, building of Zeek and tests in parallel which makes no sense.